### PR TITLE
Antrag zur Entfernung des Zwecks zur Finanzierung von Erweiterungen

### DIFF
--- a/dokumente/Vereinsstatuten.md
+++ b/dokumente/Vereinsstatuten.md
@@ -20,7 +20,6 @@ Diese Förderung beinhaltet im Besonderen:
   und weiterer Interessierter
 - Kommunikation nach innen und aussen zur Verbreitung von Wissen und Können zur Nutzung
   des Systems, insbesondere über die Websites des Projektes
-- Finanzierung von Erweiterungen
 - Weiterentwicklung des Softwareprojekts Contao Open Source CMS
 - Public Relations und Verbreitungsförderung
 


### PR DESCRIPTION
Antrag des gesamten Vorstands.

**Begründung:**
- Die Association sollte das "Unsichtbare" fördern. Geld für Extensions lässt sich - getrieben durch den Bedarf der Unternehmen - auftreiben. Hingegen ist es schwierig, Fördermittel für das Projekt an sich (Infrastruktur, Veranstaltungen, Werbemittel, Plattformen [bspw. Fundraising-Plattform, Event-Plattform], Zertifizierungen, etc.) zu finden.
- Zweck wurde noch zu Zeiten des Contao Vereins Schweiz festgehalten, ohne zu hinterfragen, was dies für Auswirkungen hat.
- Eine faire Ausschüttung stellt eine grosse Herausforderung dar.
- Warum sollte ein Mitglied einen Mitgliederbeitrag bezahlen um dann z.B. bei der GV wieder über die Verteilung an Extensions abzustimmen? Es wäre viel effizienter, das Geld direkt an die Entwickler der gewünschten Extensions zu spenden.
