### PR TITLE
Bereitstellung von Protokollen

### DIFF
--- a/dokumente/Vereinsstatuten.md
+++ b/dokumente/Vereinsstatuten.md
@@ -104,7 +104,7 @@ An der Generalversammlung besitzt jedes Aktivmitglied eine Stimme; die Beschluss
 mit einfachem Mehr. Passivmitglieder werden zur Generalversammlung eingeladen, besitzen jedoch
 kein Stimmrecht.
 
-
+Das Protokoll der Generalversammlung sowie die vorgestellte Jahresrechnung aus Punkt 3 müssen spätestens 4 Wochen nach der Generalversammlung für alle Mitglieder im Mitgliederbereich der Association Website zu Verfügung stehen. 
 
 ## Der Vorstand
 


### PR DESCRIPTION
Es ist derzeit nicht festgehalten, dass das Protokoll der Generalversammlung und andere Dokumente die auf der Generalversammlung vorgestellt wurden danach für alle Mitglieder zur Einsicht steht. Aktuell gibt es online kein Protokoll der GV 2016. Auch fehlt die Einsichtnahme in die Jahresrechnung für 2015 und 2016.

Ich bitte meinem Antrag statt zu geben da er für mehr Transparenz sorgt.