### PR TITLE
Vollständige Einladung 2 Wochen vor der GV

### DIFF
--- a/dokumente/Vereinsstatuten.md
+++ b/dokumente/Vereinsstatuten.md
@@ -89,7 +89,7 @@ Die Organe des Vereins sind:
 
 Das oberste Organ des Vereins ist die Generalversammlung. Eine ordentliche Generalversammlung
 findet jährlich statt.  
-Zur Generalversammlung werden die Mitglieder mindestens acht Wochen zum Voraus per E-Mail, unter Beilage der Traktandenliste, dem Budget für das folgende Vereinsjahr sowie der Jahresrechnung des aktuellen Vereinsjahres, eingeladen.
+Zur Generalversammlung werden die Mitglieder mindestens zwei Wochen zum Voraus per E-Mail, unter Beilage der Traktandenliste, dem Budget für das folgende Vereinsjahr sowie der Jahresrechnung des aktuellen Vereinsjahres, eingeladen.
 
 Die Generalversammlung hat die folgenden unentziehbaren Aufgaben:
 


### PR DESCRIPTION
Da die GV derzeit online statt findet (und auch geplant ist, die Teilnahme weiterhin online zu ermöglichen) sollten 2 Wochen für die vollständige Einladung ausreichen. Davon nicht betroffen ist eine Vorab-Ankündigung (formlos) des Termins