### PR TITLE
Wahl der Vorstandsmitglieder nur alle 2 Jahre

### DIFF
--- a/dokumente/Vereinsstatuten.md
+++ b/dokumente/Vereinsstatuten.md
@@ -149,6 +149,7 @@ Generalversammlung die Versammlungs- und Wahlleitung darüber in Kenntnis setzen
 Die Wahlleitung hat dann eine geheime Wahl durchzuführen. Ein Antrag auf offene Wahl kann
 nicht gestellt werden, da kein einstimmiges Votum erreicht werden kann.
 
+d) Die Vorstandsmitglieder werden für 2 Jahre gewählt.
 
 
 ## Unterschrift


### PR DESCRIPTION
Aktuell wird der Vorstand immer für ein Jahr gewählt. Da die Generalversammlung erst statt finden kann, wenn die Buchhaltung des letzten Jahres abgeschlossen ist und anschließend die Einlaungen fristgerecht versendet wurden – hat diese in den letzten Jahren frühestens im Mai statt gefunden.

Neu in den Vorstand gewählte Mitglieder hatten dann ein wenig Zeit um sich in die Vorstandsarbeit einzuarbeiten bevor zu Ende des Jahres entschieden werden musste, wer im nächsten Jahr erneut zur Wahl steht und anschließend auch gewählt wird. Die letzten Jahre haben gezeigt, dass das Team des Vorstandes optimaler zusammen arbeiten kann, wenn es sich zusammen gefunden hat (die _normalen_ Teambuilding-Prozesse statt gefunden haben) und entsprechende Abläufe, Verantwortlichkeiten sowie Themen klar und verteilt sind. Um diese _Stabilität_ zu erreichen, schlägt der Vorstand die Wahl auf 2 Jahre vor - dies soll nicht die jährliche Entlastung des Vorstandes ersetzen. Bei der bleibt es selbstverständlich weiterhin.

Andere Vorschläge sind natürlich auch jederzeit willkommen.