### PR TITLE
Update Vereinsstatuten.md

### DIFF
--- a/dokumente/Vereinsstatuten.md
+++ b/dokumente/Vereinsstatuten.md
@@ -45,13 +45,6 @@ die Generalversammlung.
 Aktivmitglied mit Stimmberechtigung kann jede natürliche Person werden, die ein Interesse
 am Vereinszweck hat.
 
-Passivmitglied ohne Stimmberechtigung kann jede natürliche und juristische Person werden,
-die ein Interesse am Vereinszweck hat.
-
-Fördermitglieder sind natürliche oder juristische Personen, welche den Verein mit finanziellen Mitteln
-unterstützen möchten, die über die bestimmten Jahresbeiträge hinausgehen.
-Fördermitglieder verfügen über kein Stimmrecht.
-
 Aufnahmegesuche sind über die offizielle Webseite des Vereins zu stellen; über die Aufnahme
 entscheidet der Vorstand.
 

--- a/dokumente/Vereinsstatuten.md
+++ b/dokumente/Vereinsstatuten.md
@@ -94,8 +94,7 @@ Die Generalversammlung hat die folgenden unentziehbaren Aufgaben:
 6. Behandlung der Ausschlussrekurse
 
 An der Generalversammlung besitzt jedes Aktivmitglied eine Stimme; die Beschlussfassung erfolgt
-mit einfachem Mehr. Passivmitglieder werden zur Generalversammlung eingeladen, besitzen jedoch
-kein Stimmrecht.
+mit einfachem Mehr. Alle Community-Mitglieder sind zur Generalversammlung willkommen, besitzen jedoch kein Stimmrecht.
 
 
 


### PR DESCRIPTION
Im 2021 hat die Contao Association neue Unterstützungsmöglichkeiten geschaffen. Gestartet mit [GitHub Sponsor,](https://contao.org/de/news/github-sponsors-fuer-contao.html) haben wir diese dank von Community-Feedback im Laufe des Jahres ausgebaut. Die neue [Übersichts-Seite](https://to.contao.org/donate) erklärt umfangreich, warum und wie Contao finanziell unterstützt werden kann und sollte. Teil dieses Programms ist die Umstellung der Contao Association-Webseite, welche neben den Mitgliedschaften im Verein auch die Supporter-Rechnungen verwaltet. Da eine Passiv- oder Fördermitgliedschaft schlussendlich nichts anderes als eine finanzielle Unterstützung von Contao ist, profitieren alle Mitglieder bei einem Wechsel zum Supporter von [entsprechenden Gegenleistungen](https://members.contao.org/de/supporter.html).

Der Vorstand schlägt daher vor, die Passiv- und Fördermitgliedschaften im Verein einzustellen und durch das Supporter-Programm zu ersetzen. Bestehende Passiv- und Fördermitglieder werden gebeten, ihre Mitgliedschaft [mit dem entsprechenden Formular](https://members.contao.org/de/abonnement.html) zu wechseln.

Die vorgeschlagene Änderung in den Statuten findest du hier im Pull-Request. Aktivmitgliedschaften bleiben selbstverständlich erhalten, schliesslich bleiben wir ein demokratisch organisierter Verein. Der Vorstand plant die Aktivmitglieder in Zukunft mehr zu aktivem Einsatz für Contao zu motivieren, beispielsweise als Helfer:innen bei Veranstaltungen, im CMS Garden oder bei anderen Projekten.